### PR TITLE
Add partner parameter to auth URL

### DIFF
--- a/ui/src/tailscale.ts
+++ b/ui/src/tailscale.ts
@@ -277,7 +277,13 @@ async function getLoginInfo(hostname: string): Promise<TailscaleUpResponse> {
   // tells us that it's already running.
   const command = `/app/background-output.sh /app/tailscale up --hostname=${hostname}-docker-desktop --accept-dns=false --json --reset --force-reauth`
   const resp = await window.ddClient.backend.execInVMExtension(command)
-  const info = JSON.parse(resp.stdout)
+  let info = JSON.parse(resp.stdout)
+  if (typeof info.AuthURL === "string") {
+    // Add referral partner info to the URL
+    const authURL = new URL(info.AuthURL)
+    authURL.searchParams.set("partner", "docker")
+    info.AuthURL = authURL.toString()
+  }
   return info as TailscaleUpResponse
 }
 


### PR DESCRIPTION
(I am a complete newb with respect to TypeScript and react, so don't be surprised if this needs to be moved or something)

This patch adds a `partner=docker` to any auth URL obtained from `tailscale up`.
I know that using the `URL` class is kind of overkill, but previous experience
has taught me that it's better not to make assumptions about the existing structure of
the URL, and to leverage JS to just handle that for us.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>