### PR TITLE
Add control server picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ To start the local UI server, navigate to `ui` and run:
 yarn start
 ```
 
-This will spin up a local server on [localhost:3000](http://localhost:3000). Once running, instruct Docker Desktop to use that server as your extension UI with the command:
+This will spin up a local server on [localhost:3011](http://localhost:3011). Once running, instruct Docker Desktop to use that server as your extension UI with the command:
 
 ```
-docker extension dev ui-source <extension-id> http://localhost:3000
+docker extension dev ui-source <extension-id> http://localhost:3011
 ```

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3011 react-scripts start",
     "build": "react-scripts build",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'"

--- a/ui/src/components/dropdown-menu.tsx
+++ b/ui/src/components/dropdown-menu.tsx
@@ -55,15 +55,18 @@ DropdownMenu.defaultProps = {
 DropdownMenu.Group = DropdownMenuGroup
 DropdownMenu.Item = DropdownMenuItem
 DropdownMenu.Link = DropdownMenuLink
+DropdownMenu.Label = DropdownLabel
+DropdownMenu.ItemIndicator = DropdownItemIndicator
 DropdownMenu.RadioGroup = MenuPrimitive.RadioGroup
-DropdownMenu.RadioItem = MenuPrimitive.RadioItem
+DropdownMenu.RadioItem = DropdownRadioItem
 /**
  * DropdownMenu.Separator should be used to divide items into sections within a
  * DropdownMenu.
  */
 DropdownMenu.Separator = DropdownSeparator
 
-const menuItemClasses = "block px-4 py-2"
+const menuItemPadding = "pl-5 pr-4 py-2"
+const menuItemClasses = cx("block", menuItemPadding)
 const menuItemInteractiveClasses =
   "cursor-pointer focus:outline-none hover:enabled:bg-gray-100 focus:bg-gray-100 dark:hover:enabled:bg-[#5E6971] dark:focus:bg-[#5E6971]"
 
@@ -171,6 +174,53 @@ function DropdownSeparator(props: DropdownSeparatorProps) {
       className={cx(
         "my-1 border-b border-gray-200 dark:border-white dark:opacity-10",
         className,
+      )}
+      {...rest}
+    />
+  )
+}
+
+function DropdownLabel(props: MenuPrimitive.MenuLabelProps) {
+  const { className, ...rest } = props
+  return (
+    <MenuPrimitive.Label
+      className={cx(
+        className,
+        menuItemClasses,
+        "text-xs text-gray-500 dark:text-gray-400",
+      )}
+      {...rest}
+    />
+  )
+}
+
+function DropdownRadioItem(props: MenuPrimitive.MenuRadioItemProps) {
+  const { className, disabled, ...rest } = props
+
+  return (
+    <MenuPrimitive.RadioItem
+      className={cx(
+        "relative",
+        className,
+        menuItemClasses,
+        menuItemInteractiveClasses,
+        {
+          "text-gray-400 bg-white cursor-default": disabled,
+        },
+      )}
+      disabled={disabled}
+      {...rest}
+    />
+  )
+}
+
+function DropdownItemIndicator(props: MenuPrimitive.MenuItemIndicatorProps) {
+  const { className, ...rest } = props
+  return (
+    <MenuPrimitive.ItemIndicator
+      className={cx(
+        className,
+        "absolute right-4 top-1/2 -translate-y-1/2 z-20",
       )}
       {...rest}
     />

--- a/ui/src/components/icon.tsx
+++ b/ui/src/components/icon.tsx
@@ -106,6 +106,20 @@ const icons: Record<string, React.FC<IconProps>> = {
       <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
     </svg>
   ),
+  dot: (props: IconProps) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="1"></circle>
+    </svg>
+  ),
 }
 
 export default function Icon(props: {

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,4 +1,21 @@
 /**
+ * timeout allows setting a max deadline for a promise to be executed.
+ */
+export function timeout<T>(task: Promise<T>, timeout: number) {
+  let timer: number
+  return Promise.race([
+    task,
+    new Promise(
+      (_, reject) =>
+        (timer = window.setTimeout(
+          () => reject(new Error("Exceeded timeout")),
+          timeout,
+        )),
+    ),
+  ]).finally(() => window.clearTimeout(timer)) as Promise<T>
+}
+
+/**
  * openBrowser opens a URL in the host system's browser
  */
 export async function openBrowser(url: string) {


### PR DESCRIPTION
This commit adds an item to the account menu dropdown that allows choosing a control server to use for logins, to make it easier to test Docker related changes to the control server.

<img width="333" alt="Screenshot 2022-01-26 at 17 51 49@2x" src="https://user-images.githubusercontent.com/303731/151260504-d9a687a9-5ab0-4fdc-abbe-4e47523ed983.png">

This still needs two pieces:

- Figure out how to refer to `localhost:31544` from inside the Docker VM — it seems to not even be able to find the control server
- Find a better home for it, preferably from the login view

Fixes #8 

/cc @dblohm7 