### PR TITLE
Improve container watching code

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dropdown-menu": "^0.1.4",
     "@radix-ui/react-tooltip": "^0.1.6",
     "classnames": "^2.3.1",
+    "mitt": "^3.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "zustand": "^3.6.8"

--- a/ui/src/entry.tsx
+++ b/ui/src/entry.tsx
@@ -26,6 +26,7 @@ const selector = (state: State) => ({
   fetchHostname: state.fetchHostname,
   fetchStatus: state.fetchStatus,
   fetchHostStatus: state.fetchHostStatus,
+  fetchContainers: state.fetchContainers,
 })
 
 function Router() {
@@ -36,7 +37,10 @@ function Router() {
     fetchHostname,
     fetchStatus,
     fetchHostStatus,
+    fetchContainers,
   } = useTailscale(selector, shallow)
+
+  const onboarding = showOnboarding(backendState, loginUser)
 
   useEffect(() => {
     fetchHostname()
@@ -44,6 +48,9 @@ function Router() {
 
   useInterval(fetchStatus, 5000)
   useInterval(fetchHostStatus, 10000)
+  // We slowly fetch containers in the onboarding view to make sure we have some
+  // preloaded data before users log in.
+  useInterval(fetchContainers, onboarding ? 20000 : null)
 
   if (!initialized) {
     return <LoadingView />
@@ -51,7 +58,7 @@ function Router() {
   if (backendState === "NeedsMachineAuth") {
     return <NeedsAuthView />
   }
-  if (showOnboarding(backendState, loginUser)) {
+  if (onboarding) {
     return <OnboardingView />
   }
   return <ContainerView />

--- a/ui/src/hooks/interval.ts
+++ b/ui/src/hooks/interval.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef } from "react"
 
-export default function useInterval(fetcher: () => void, interval: number) {
+export default function useInterval(
+  fetcher: () => void,
+  interval: number | null,
+) {
   const savedFetcher = useRef<() => void>()
 
   useEffect(() => {

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -34,6 +34,21 @@ export function isMacOS() {
   return navigator.userAgent.match(/Macintosh/i)
 }
 
+/**
+ * debounce limits the number of times fn is called within a given time period.
+ */
+export function debounce<T extends (...args: any[]) => any>(
+  fn: T,
+  wait: number = 200,
+) {
+  let timeoutId = 0
+  let callable = (...args: Parameters<T>) => {
+    clearTimeout(timeoutId)
+    timeoutId = window.setTimeout(() => fn(...args), wait)
+  }
+  return callable
+}
+
 // HACK: temporarily using this until we update the `tailscale status --json`
 // to give us a domain by itself. This list is duplicated from a control export
 // and these lines https://github.com/tailscale/corp/blob/main/control/cfgdb/cfgdb.go#L812-L1025

--- a/ui/src/views/container-view.tsx
+++ b/ui/src/views/container-view.tsx
@@ -14,7 +14,6 @@ import copyToClipboard from "src/lib/clipboard"
 import { navigateToContainerLogs, openBrowser } from "src/utils"
 import Icon from "src/components/icon"
 import useTimedToggle from "src/hooks/timed-toggle"
-import useInterval from "src/hooks/interval"
 
 type ConfirmLogoutAction = "logout" | "none"
 
@@ -24,7 +23,6 @@ const selector = (state: State) => ({
   connect: state.connect,
   disconnect: state.disconnect,
   switchAccount: state.switchAccount,
-  fetchContainers: state.fetchContainers,
   logout: state.logout,
 })
 
@@ -33,19 +31,13 @@ const selector = (state: State) => ({
  * the list of containers and Tailscale URLs they can use to access them.
  */
 export default function ContainerView() {
-  const {
-    backendState,
-    loginUser,
-    fetchContainers,
-    connect,
-    disconnect,
-    logout,
-  } = useTailscale(selector, shallow)
+  const { backendState, loginUser, connect, disconnect, logout } = useTailscale(
+    selector,
+    shallow,
+  )
   const [connecting, setConnecting] = useState(false)
   const [confirmLogoutAction, setConfirmLogoutAction] =
     useState<ConfirmLogoutAction>("none")
-
-  useInterval(fetchContainers, 3000)
 
   const handleConnectClick = useCallback(async () => {
     setConnecting(true)

--- a/ui/src/views/container-view.tsx
+++ b/ui/src/views/container-view.tsx
@@ -14,6 +14,7 @@ import copyToClipboard from "src/lib/clipboard"
 import { navigateToContainerLogs, openBrowser } from "src/utils"
 import Icon from "src/components/icon"
 import useTimedToggle from "src/hooks/timed-toggle"
+import useInterval from "src/hooks/interval"
 
 type ConfirmLogoutAction = "logout" | "none"
 
@@ -23,6 +24,7 @@ const selector = (state: State) => ({
   connect: state.connect,
   disconnect: state.disconnect,
   switchAccount: state.switchAccount,
+  fetchContainers: state.fetchContainers,
   logout: state.logout,
 })
 
@@ -31,13 +33,19 @@ const selector = (state: State) => ({
  * the list of containers and Tailscale URLs they can use to access them.
  */
 export default function ContainerView() {
-  const { backendState, loginUser, connect, disconnect, logout } = useTailscale(
-    selector,
-    shallow,
-  )
+  const {
+    backendState,
+    loginUser,
+    fetchContainers,
+    connect,
+    disconnect,
+    logout,
+  } = useTailscale(selector, shallow)
   const [connecting, setConnecting] = useState(false)
   const [confirmLogoutAction, setConfirmLogoutAction] =
     useState<ConfirmLogoutAction>("none")
+
+  useInterval(fetchContainers, 3000)
 
   const handleConnectClick = useCallback(async () => {
     setConnecting(true)

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1065,17 +1065,17 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4"
   integrity sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==
 
-"@docker/extension-api-client-types@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.2.2.tgz#b8504df0d4dfaa5bc4e5201482f001378bcfc4aa"
-  integrity sha512-+RiekqZ7sacKZpIm3SguRLX+YurCwNhgBGrUoLdY8PIYKzJ6NZd2+ExX3wyT+lxCYOFEW9Yh/gdcXWvjVOktzw==
+"@docker/extension-api-client-types@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.2.3.tgz#4711e81a18266bf7e8b15734cd7daeb221db1312"
+  integrity sha512-KecgDPmH0Ma7UpwQGAbVQnMCFC9dLvlngWT0jP0uXObxISaPVhHnOzbb+5d+VikazV82Dj7E24ySKJOpKUYHDA==
 
 "@docker/extension-api-client@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@docker/extension-api-client/-/extension-api-client-0.2.2.tgz#d3dba6f3bbaebe66f80181581312bbfc302560b9"
-  integrity sha512-/mUxXrzxadU9EMd4NiR1c3upshSzo0C9DgkdDu1O+CsSp8Ia+9C2XlIlh5lb200DdtYqSNlqs4KWhIoHMPkx/A==
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client/-/extension-api-client-0.2.3.tgz#902c375860002c3ebc12acf0d43d7a524385cf99"
+  integrity sha512-iqZTGAIOuKLpUqO9fVUAKbHYGs4UUN+AshXM8R31TNGZC9v9ukHuilqoVBpXuwq8MflPEAvLyGuTvdEr2x8EPQ==
   dependencies:
-    "@docker/extension-api-client-types" "^0.2.2"
+    "@docker/extension-api-client-types" "^0.2.3"
 
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6039,6 +6039,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+mitt@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"


### PR DESCRIPTION
This PR updates our extension to use newer Docker APIs, and load container information separate from Tailscale status information. After I get answers to some questions, I'll update this PR to use `docker events` to watch for changes to containers, rather than constantly polling.