### PR TITLE
Add MagicDNS support

### DIFF
--- a/ui/src/components/icon.tsx
+++ b/ui/src/components/icon.tsx
@@ -61,6 +61,38 @@ const icons: Record<string, React.FC<IconProps>> = {
       <polyline points="6 9 12 15 18 9"></polyline>
     </svg>
   ),
+  more: (props: IconProps) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="1"></circle>
+      <circle cx="12" cy="5" r="1"></circle>
+      <circle cx="12" cy="19" r="1"></circle>
+    </svg>
+  ),
+  "external-link": (props: IconProps) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+      <polyline points="15 3 21 3 21 9"></polyline>
+      <line x1="10" y1="14" x2="21" y2="3"></line>
+    </svg>
+  ),
   info: (props: IconProps) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -9,6 +9,13 @@ export async function openBrowser(url: string) {
   return ddClient.host.openExternal(url)
 }
 
+export function navigateToContainerLogs(containerId: string) {
+  // These functions aren't included on the official Docker typings, but they're
+  // present.
+  // @ts-ignore
+  ddClient.navigateToContainerLogs(containerId)
+}
+
 /**
  * isWindows detects if the current host system is Windows. We rely on the
  * assumption that the Electron instance will give us the right `userAgent`


### PR DESCRIPTION
This commit adds MagicDNS support by looking for when MagicDNS is enabled on the tailnet, and replacing IP addresses with DNS names in the Tailscale IP column.

It also adds a new "more" option to the table which allows users to copy the IP address, even if MagicDNS is enabled.