### PR TITLE
Add marketplace metadata to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,15 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn bu
 
 FROM debian:bullseye-slim
 LABEL org.opencontainers.image.title="Tailscale" \
-    com.docker.desktop.extension.icon="https://tailscale.com/files/tailscale-docker-icon.svg" \
     org.opencontainers.image.description="Connect your Docker containers to your secure private network." \
     org.opencontainers.image.authors="Tailscale Inc." \
     org.opencontainers.image.vendor="Tailscale Inc." \
-    com.docker.desktop.extension.api.version=">=0.1.0"
+    com.docker.desktop.extension.icon="https://tailscale.com/files/tailscale-docker-icon.svg" \
+    com.docker.desktop.extension.api.version=">=0.2.3" \
+    com.docker.extension.screenshots='[{"alt": "A list of Docker containers in the Tailscale extension. A caption that says: Connect Docker to your private network. Share development servers with teammates, or remotely access private resources.", "url": "https://tailscale.com/files/images/docker/docker-screenshot-1.png"},{"alt": "A Docker container with a tooltip that says Open in Browser. A browser next to it with a website. A caption that says Easy access, from anywhere. Tailscale gives your containers a static IP and easy DNS name. It works even across firewalls and containerization layers.", "url": "http://localhost:9000/files/images/docker/docker-screenshot-1.png"}]' \
+    com.docker.extension.detailed-description="<p>Tailscale’s Docker Desktop extension lets you connect your containers to your Tailscale network. Any containers with exposed ports are available to others on the same tailnet (Tailscale network).</p><p>Tailscale lets you:</p><ul><li>Share development servers with your teammates</li><li>Access databases and sensitive development resources without exposing them to the public internet</li><li>Use <em>MagicDNS</em> to obtain shortnames for accessing your devices and containers</li></ul><h3>About Tailscale</h3><p>Tailscale lets you create a secure, virtual private network to connect your devices in minutes. This network connects devices anywhere in the world, no matter what firewalls or containerization layers are in-between them. And Tailscale provides robust access control rules enforced by each device, so users on your network can only access what they’re allowed to.</p><p>For more details, visit <em>tailscale.com</em>." \
+    com.docker.extension.publisher-url="https://tailscale.com"\
+    com.docker.extension.additional-urls='[{"title":"Website","url":"https://tailscale.com/"},{"title":"Documentation","url":"https://tailscale.com/kb/"},{"title":"Support","url":"https://tailscale.com/contact/support"},{"title":"Terms of Service","url":"https://tailscale.com/terms"},{"title":"Privacy policy","url":"https://tailscale.com/privacy-policy"}]'
 RUN apt-get update \
     && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
This commit adds marketplace metadata to the Dockerfile to include more detailed descriptions, links, and images for the Docker Desktop extension marketplace.

Still need to add screenshots and review the content with the team.

![Screenshot 2022-04-18 at 16 42 06@2x](https://user-images.githubusercontent.com/303731/163874690-93d28fa3-fd17-424d-8f7f-8a6697db0513.png)

Fixes #27 