### PR TITLE
Remove Docker CSS theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ extension: ## Build service image to be deployed as a desktop extension
 .PHONY: extension
 
 install-extension: extension ## Install extension image Docker desktop
-	docker extension update $(LOCAL_IMAGE_NAME)
+	@if $$(docker extension ls | grep -q $(LOCAL_IMAGE_NAME)); \
+		then docker extension update $(LOCAL_IMAGE_NAME); \
+		else docker extension install $(LOCAL_IMAGE_NAME); fi
 .PHONY: install-extension
 
 dev-extension: install-extension
@@ -27,7 +29,7 @@ dev-extension: install-extension
 .PHONY: dev-extension
 
 remove-extension:
-	@docker extension remove $(LOCAL_IMAGE_NAME)
+	@docker extension rm $(LOCAL_IMAGE_NAME)
 .PHONY: remove-extension
 
 push-extension: ## Build & Upload extension image to hub. Do not push if tag already exists: make push-extension tag=0.1

--- a/ui/src/components/tooltip.tsx
+++ b/ui/src/components/tooltip.tsx
@@ -36,7 +36,7 @@ export default function Tooltip(props: Props) {
         {children}
       </Primitive.Trigger>
       <Primitive.Content
-        className="tooltip px-2 py-1 bg-[#5e6971] text-white text-center rounded-md max-w-xs"
+        className="tooltip px-2 py-1 bg-[#5e6971] text-white text-sm text-center rounded-md max-w-xs"
         sideOffset={sideOffset}
       >
         {content}

--- a/ui/src/entry.tsx
+++ b/ui/src/entry.tsx
@@ -14,6 +14,8 @@ import NeedsAuthView from "src/views/needs-auth-view"
 import OnboardingView from "src/views/onboarding-view"
 
 export default function App() {
+  useRemoveDockerStyles()
+
   return (
     <Tooltip.Provider>
       <div className="text-sm h-full">
@@ -106,4 +108,20 @@ const showOnboarding = (state: BackendState, user?: object) => {
     return true
   }
   return false
+}
+
+/**
+ * useRemoveDockerStyles removes the `dockerDesktopTheme` classname that gets
+ * injected by Docker Desktop. These styles seem like they may change regularly,
+ * so opting out lets us control our UI better, and only make changes when
+ * necessary.
+ */
+function useRemoveDockerStyles() {
+  useEffect(() => {
+    const dockerThemeClass = "dockerDesktopTheme"
+    const $body = document.body;
+    if ($body && $body.classList.contains(dockerThemeClass)) {
+      $body.classList.remove(dockerThemeClass)
+    }
+  }, [])
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -21,7 +21,25 @@
   html,
   body,
   #root {
-    height: 100%;
+    @apply font-sans text-base h-full antialiased;
+  }
+
+  body {
+    /**
+     * We apply some default values from Docker Desktop's default theme prior to
+     * version 4.9. This is overriden in the #root declaration below.
+     */
+    @apply bg-[#f4f4f6] dark:bg-[#202c33] text-[rgba(0,0,0,0.87)] dark:text-white p-0;
+  }
+
+  #root {
+    /**
+     * We override the body styles here to prevent Docker's theme
+     * from affecting us.
+     */
+    background-color: var(--dd-color-background);
+    color: var(--dd-text-color-primary);
+    padding: var(--dd-page-padding-top, 1.5rem) var(--dd-page-padding-right, 1.5rem) var(--dd-page-padding-bottom, 1.5rem) var(--dd-page-padding-left, 1.5rem);
   }
 }
 

--- a/ui/src/views/container-view.tsx
+++ b/ui/src/views/container-view.tsx
@@ -70,7 +70,7 @@ export default function ContainerView() {
           longer be able to access your containers.
         </p>
       </Dialog>
-      <header className="flex items-center justify-between py-5">
+      <header className="flex items-center justify-between pb-5">
         <div>
           <div className="font-semibold text-xl">Tailscale</div>
           <div className="flex items-center text-gray-500 dark:text-gray-400">

--- a/ui/src/views/loading-view.tsx
+++ b/ui/src/views/loading-view.tsx
@@ -12,7 +12,7 @@ export default function LoadingView() {
     <div className="w-full h-full flex justify-center">
       <div
         className={cx(
-          "rounded-full border-gray-400 dark:border-gray-500 border-4 border-t-transparent dark:border-t-transparent w-12 h-12 animate-spin duration-[1.5s] transition mt-28",
+          "rounded-full border-gray-600 dark:border-gray-500 border-4 border-t-transparent dark:border-t-transparent w-12 h-12 animate-spin duration-[1.5s] transition mt-28",
           {
             "opacity-0": !mounted,
             "opacity-100": mounted,

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -34,10 +34,17 @@ module.exports = {
         "docker-gray-200": "#E1E2E6",
         "docker-gray-100": "#F9F9FA",
 
+        "docker-blue-300": "var(--dd-color-blue-300)",
+        "docker-blue-500": "var(--dd-color-blue-500)",
+        "docker-blue-700": "var(--dd-color-blue-700)",
+
         "faded-gray-5": "rgba(31,41,55,0.05)",
         "faded-gray-15": "rgba(31,41,55,0.15)",
         "faded-gray-25": "rgba(31,41,55,0.25)",
         "faded-white-5": "rgba(255,255,255,0.05)",
+      },
+      fontFamily: {
+        sans: ["Open SansVariable", "Open Sans", "-apple-system", "sans-serif"],
       },
       boxShadow: {
         avatar:


### PR DESCRIPTION
This PR updates our extension to remove some default styles provided to us by Docker. It seems like these will change on a regular basis, which may lead to a fair bit of bitrot for us. Rather than inherit their changes, this PR updates our styles to not inherit anything except for a few select CSS variables which we include in our Tailwind config.

There's likely more work here to correspond with future Docker updates — for example we can't yet use Docker's `--dd-color-blue-500` variable for buttons because they don't expose variants for things like hover colors or focused styles. Later updates with a more fleshed out set of colors may allow us to hook into more of their theme.

But for now, this PR gives us a stable footing between Docker versions, needing to worry a little less about bitrot.