### PR TITLE
Fix host Tailscale detection on case-sensitive filesystems

### DIFF
--- a/ui/src/tailscale.ts
+++ b/ui/src/tailscale.ts
@@ -434,7 +434,7 @@ const windowsTailscalePath = async () => {
   return `"${output.stdout.trim()}"`
 }
 const macOSTailscalePath =
-  "/Applications/Tailscale.app/Contents/MacOS/tailscale"
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 const linuxTailscalePath = "/usr/bin/env tailscale"
 
 async function isTailscaleOnHost(): Promise<boolean> {


### PR DESCRIPTION
This commit updates the path to the Tailscale binary on macOS. I erroneously had the binary name lowercased as `tailscale`, but it's actually `Tailscale`. On case-sensitive APFS filesystems, this caused the detection and subsequent host commands to fail.

Fixes #34