### PR TITLE
all: bump Tailscale version to 1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine AS tailscale
 RUN apk add --no-cache curl
 ARG TARGETARCH
-ARG TSVERSION=1.22.1
+ARG TSVERSION=1.30.1
 RUN curl -fSsLo /tmp/tailscale.tgz https://pkgs.tailscale.com/stable/tailscale_${TSVERSION}_${TARGETARCH}.tgz \
     && mkdir /out \
     && tar -C /out -xzf /tmp/tailscale.tgz --strip-components=1


### PR DESCRIPTION
Basic local testing:

<img width="600" alt="Screen Shot 2022-09-15 at 11 13 52 AM" src="https://user-images.githubusercontent.com/1112/190481283-958476d4-925e-46ee-93c0-6f55ab968629.png">

Also spun up a simple container inside Docker Desktop and successfully connected to it using the Tailscale hostname from a different machine on my tailnet.