### PR TITLE
Fix local extension development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDER=buildx-multi-arch
 
-LOCAL_IMAGE_NAME=tailscale-docker-extension
+LOCAL_IMAGE_NAME=tailscale/docker-extension-dev
 REMOTE_IMAGE_NAME=tailscale/docker-extension
 
 STATIC_FLAGS=CGO_ENABLED=0


### PR DESCRIPTION
Due to a Docker Desktop issue (docker/extensions-sdk#215), all local extension containers need to have a namespace prefix before a slash (eg. tailscale/my-extension). Failure to do so can cause issues when trying to remove extensions.

While the bug might be fixed, it seems like this prefix is recommended anyways, so we'll keep it around for the long term.