### PR TITLE
chore: replace deprecated method by the new method for navigation

### DIFF
--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -10,10 +10,7 @@ export async function openBrowser(url: string) {
 }
 
 export function navigateToContainerLogs(containerId: string) {
-  // These functions aren't included on the official Docker typings, but they're
-  // present.
-  // @ts-ignore
-  ddClient.navigateToContainerLogs(containerId)
+  ddClient.desktopUI.navigate.viewContainerLogs(containerId)
 }
 
 /**


### PR DESCRIPTION
replace deprecated method and use the one exposed by the SDK
https://docs.docker.com/desktop/extensions-sdk/dev/api/reference/interfaces/NavigationIntents/#viewcontainerlogs

I found this while trying this extension in Podman Desktop