### PR TITLE
fix: broken args, up is a separate arg

### DIFF
--- a/ui/src/tailscale.ts
+++ b/ui/src/tailscale.ts
@@ -411,7 +411,8 @@ async function getLoginInfo(hostname: string): Promise<TailscaleUpResponse> {
   // change their account. If we call `up` without `--force-reauth`, it just
   // tells us that it's already running.
   const resp = await vmExec("/app/background-output.sh", [
-    "/app/tailscale up",
+    "/app/tailscale",
+    "up",
     `--hostname=${hostname}-docker-desktop`,
     `--accept-dns=false`,
     `--json`,


### PR DESCRIPTION
while testing this extension in Podman Desktop and the support of Docker Desktop extensions, there was an error reported on my side.

I figured out that it's because the arguments are not separated.

I guess Docker Desktop is sending the call through a CLI call so space don't matters but if we send using REST API, 'tailscale up' should be split into two args, 'tailscale' and 'up'