### PR TITLE
Update to Tailscale 1.48.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine AS tailscale
 RUN apk add --no-cache curl
 ARG TARGETARCH
-ARG TSVERSION=1.36.2
+ARG TSVERSION=1.48.1
 RUN curl -fSsLo /tmp/tailscale.tgz https://pkgs.tailscale.com/stable/tailscale_${TSVERSION}_${TARGETARCH}.tgz \
     && mkdir /out \
     && tar -C /out -xzf /tmp/tailscale.tgz --strip-components=1


### PR DESCRIPTION
This commit updates Tailscale to the latest version to take advantage of a few new features and bug fixes that have come out since 1.36.2.