### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine AS tailscale
 RUN apk add --no-cache curl
 ARG TARGETARCH
-ARG TSVERSION=1.58.2
+ARG TSVERSION=1.66.4
 RUN curl -fSsLo /tmp/tailscale.tgz https://pkgs.tailscale.com/stable/tailscale_${TSVERSION}_${TARGETARCH}.tgz \
     && mkdir /out \
     && tar -C /out -xzf /tmp/tailscale.tgz --strip-components=1


### PR DESCRIPTION
Update Dockerfile to latest available tailscale version

Noticed that on my connected machines page that my Docker extension machine was an old version
![image](https://github.com/tailscale/docker-extension/assets/1258642/235f2147-f761-487b-93c1-ccaf65431c89)

Looking at #61 for reference (which was set to 1.58.2 as in my screenshot) I updated this argument to the latest available version I saw on https://pkgs.tailscale.com/stable/#static